### PR TITLE
Fix #137 Change module from UMD to CJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2025-10-09
+### Changed
+- module is now CJS instead of UMD ([#137](https://github.com/rcjsuen/dockerfile-language-service/issues/137))
+
 ## [0.15.1] - 2025-07-21
 ### Fixed
 - fix TypeError from being thrown if the position of definition, highlight range, or rename calculations are from outside the document ([#132](https://github.com/rcjsuen/dockerfile-language-service/issues/132))
@@ -547,7 +551,8 @@ let workspaceEdit = {
     - textDocument/rename
     - textDocument/hover
 
-[Unreleased]: https://github.com/rcjsuen/dockerfile-language-service/compare/v0.15.1...HEAD
+[Unreleased]: https://github.com/rcjsuen/dockerfile-language-service/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/rcjsuen/dockerfile-language-service/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/rcjsuen/dockerfile-language-service/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/rcjsuen/dockerfile-language-service/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/rcjsuen/dockerfile-language-service/compare/v0.13.0...v0.14.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dockerfile-language-service",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dockerfile-language-service",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "dockerfile-ast": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dockerfile",
     "moby"
   ],
-  "version": "0.15.1",
+  "version": "0.16.0",
   "author": "Remy Suen",
   "license": "MIT",
   "bugs": "https://github.com/rcjsuen/dockerfile-language-service/",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es5",
-        "module": "umd",
+        "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": false,
         "outDir": "../lib",


### PR DESCRIPTION
Fixes #137. I figured the safest thing to do was bump the version to indicate a breaking change.